### PR TITLE
Fix run_pipeline script path

### DIFF
--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 echo "🚀 Running MeTTa Task Pipeline..."
-swipl -q -s run_pipeline.pl
+swipl -q -s prolog/run_pipeline.pl


### PR DESCRIPTION
## Summary
- adjust `run_pipeline.sh` to run the Prolog script from the `prolog` folder
- remove leading blank line so shebang is first
- mark the script as executable

## Testing
- `swipl -q -s prolog/run_tests.pl` *(fails: `source_sink` errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f479ac8d083258de101334047c3ad