### PR TITLE
Fix reorder_sync_pool module header

### DIFF
--- a/prolog/reorder_sync_pool.pl
+++ b/prolog/reorder_sync_pool.pl
@@ -6,12 +6,11 @@ Supports various modes: sequential, per-task threads, or N-threaded groupings.
 
 
 :- module(reorder_sync_pool,
-    [run_sync_task_pool/3,
-     run_sync_task_pool_optimal/3])
+          [ run_sync_task_pool/3,
+            run_sync_task_pool_optimal/3
+          ]).
 
-:- use_module(reorder_task_static, [group_parallel_stages/4]). [
-    run_sync_task_pool/3
-]).
+:- use_module(reorder_task_static, [group_parallel_stages/4]).
 
 :- use_module(threaded_attvar).
 
@@ -59,10 +58,6 @@ task_list_when_ready(TaskList) :-
 
 
 :- use_module(threaded_attvar, [shared_variables/2, copy_term_with_sync/5]).
-
-%% :-
-    copy_term_with_sync(task_list_when_ready(TaskGroup), Copy, _, _, SharedVars),
-    threaded_attvar:sync_thread_create(Copy, ThreadID, []).
 
 
 

--- a/prolog/reorder_task_static.pl
+++ b/prolog/reorder_task_static.pl
@@ -475,8 +475,6 @@ annotate_goals([G|Gs], [(Pol,G2)|Rest]) :-
     annotated_goal:annotated_goal(G, G2, _, Ps),
     ( Ps = [Pol|_] -> true ; Pol = none ),
     annotate_goals(Gs, Rest).
-    strip_annotation(G, G2, Policy),
-    annotate_goals(Gs, Rest).
 
 %! group_parallel_stages_policy(+Annotated:list, +PreBound:list, +Acc:list, -Stages:list, -Leftovers:list)
 group_parallel_stages_policy([], _, Acc, Acc, []).
@@ -559,9 +557,5 @@ inline_all_code([], _, []).
 inline_all_code([Clause|Rest], Except, [NewClause|Out]) :-
     Clause = (Head :- Body),
     deep_inline:deep_inline_body(Body, Except, InlinedBody),
-    NewClause = (Head :- InlinedBody),
-    inline_all_code(Rest, Except, Out).
-    Clause = (Head :- Body),
-    deep_inline_body(Body, Except, InlinedBody),
     NewClause = (Head :- InlinedBody),
     inline_all_code(Rest, Except, Out).


### PR DESCRIPTION
## Summary
- clean up `reorder_sync_pool` module declaration
- trim duplicate code in `reorder_task_static` and `threaded_attvar`
- ensure SWI-Prolog can load `reorder_sync_pool.pl`

## Testing
- `swipl -q -t halt -s prolog/reorder_sync_pool.pl`
- `swipl -q -g "[prolog/run_tests], run_tests." -t halt | head`

------
https://chatgpt.com/codex/tasks/task_e_686f716805948325a1c767b2e60d54b3